### PR TITLE
implement utils for ComponentStruct (#5)

### DIFF
--- a/contracts/components/location/Location.cairo
+++ b/contracts/components/location/Location.cairo
@@ -44,12 +44,10 @@ func set{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     // check init
 
     // cast data to struct so we can store it
-    // TODO: CAST FUNCTION HERE - we need to cast the data to the struct
+    // we offset data by two so we only store new location
+    let loc: ComponentStruct = Utils.arr_to_component_struct(2, data + 2);
 
-    let x = data[0];
-    let y = data[1];
-
-    component.write(entity, ComponentStruct(x, y));
+    component.write(entity, loc);
 
     // call World with state update to trigger event
     let (world_address) = World.get_world_address();

--- a/contracts/utils/Utils.cairo
+++ b/contracts/utils/Utils.cairo
@@ -1,19 +1,23 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.registers import get_fp_and_pc
+from contracts.components.location.Constants import ComponentStruct
 
 namespace Utils {
     // Since we cannot send arbitrary data to the contract, we need to cast the struct to an array
-    func struct_to_array{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        entity: felt, value: felt
-    ) {
-        // TODO: Cast and return
-        return ();
+    func component_struct_to_arr{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        value: ComponentStruct
+    ) -> (arr_len: felt, arr: felt*) {
+        let (__fp__, _) = get_fp_and_pc();
+        return (ComponentStruct.SIZE, &value);
     }
-    func array_to_struct{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        entity: felt, value: felt
-    ) {
-        // TODO: Cast and return
-        return ();
+    func arr_to_component_struct{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        arr_len: felt, arr: felt*
+    ) -> ComponentStruct {
+        assert arr_len = ComponentStruct.SIZE;
+
+        let cs: ComponentStruct* = cast(arr, ComponentStruct*);
+        return ([cs]);
     }
 }


### PR DESCRIPTION
Per discussion, we implement an example of arr<>struct casting as a template for an author to adapt.